### PR TITLE
Fix $toggle

### DIFF
--- a/src/View.ts
+++ b/src/View.ts
@@ -197,7 +197,7 @@ class View extends BaseView {
                 props.shift();
             }
             else {
-                if (props[0] == 'view') {
+                if (props[0] === 'view') {
                     propTarget = this;
                     props.shift();
                 } else {


### PR DESCRIPTION
With the recent changes, $toggle broke as propTarget was resolving to the owner, rather than the instance. This fixes it, and still maintains all of the fixes for dropdown etc.
