### PR TITLE
Remove accessors from Queue implementation

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -51,8 +51,8 @@ class Task implements ITaskState {
 }
 
 export interface IQueue {
-    before: IQueue;
-    after: IQueue;
+    before(): IQueue;
+    after(): IQueue;
     schedule(work: Function, insertAtTop?: boolean, name?: string): number;
 }
 
@@ -62,11 +62,11 @@ class Queue implements IQueue {
     _after: Queue;
     _work: Task[] = [];
 
-    get before() {
+    before() {
         return this._before || (this._before = new Queue());
     }
 
-    get after() {
+    after() {
         return this._after || (this._after = new Queue());
     }
 

--- a/test/Scheduler.test.ts
+++ b/test/Scheduler.test.ts
@@ -162,7 +162,7 @@ describe('Scheduler', function () {
         it('should execute before tasks first', function (done) {
             var count = 0;
 
-            Scheduler.main.before.schedule(function () {
+            Scheduler.main.before().schedule(function () {
                 assert.strictEqual(count, 0);
                 count++;
             });
@@ -174,7 +174,7 @@ describe('Scheduler', function () {
         });
 
         it('should have an after that is distinct from main', function () {
-            assert.notStrictEqual(Scheduler.main.before.after, Scheduler.main);
+            assert.notStrictEqual(Scheduler.main.before().after(), Scheduler.main);
         });
 
     });
@@ -188,14 +188,14 @@ describe('Scheduler', function () {
                 count++;
             });
 
-            Scheduler.main.after.schedule(function () {
+            Scheduler.main.after().schedule(function () {
                 assert.strictEqual(count, 1);
                 done();
             });
         });
 
         it('should have a before that is distinct from main', function () {
-            assert.notStrictEqual(Scheduler.main.after.before, Scheduler.main);
+            assert.notStrictEqual(Scheduler.main.after().before(), Scheduler.main);
         });
     });
 
@@ -263,7 +263,7 @@ describe('Scheduler', function () {
 
             var count = 0;
 
-            Scheduler.main.after.schedule(function () {
+            Scheduler.main.after().schedule(function () {
                 assert.strictEqual(count, 2);
                 done();
             }, false, "third");
@@ -273,7 +273,7 @@ describe('Scheduler', function () {
                 count++;
             }, false, "second");
 
-            Scheduler.main.before.schedule(function () {
+            Scheduler.main.before().schedule(function () {
                 assert.strictEqual(count, 0);
                 count++;
             }, false, "first");
@@ -296,7 +296,7 @@ describe('Scheduler', function () {
         });
 
         it('should reflect the queue of the current task', function (done) {
-            var beforeQueue = Scheduler.main.before;
+            var beforeQueue = Scheduler.main.before();
 
             beforeQueue.schedule(function () {
                 assert.strictEqual(Scheduler.activeQueue, beforeQueue);


### PR DESCRIPTION
Allows components more flexibility in target instead of locking down
to ECMAScript5 as a requirement.
