### PR TITLE
Verify Block#update doesn't update view values incorrectly

### DIFF
--- a/test/Block.test.ts
+++ b/test/Block.test.ts
@@ -341,6 +341,20 @@ describe('Block', function () {
             block.dispose();
 
         });
+
+        it('handles nonstandard prototypes', function() {
+            String.prototype['foo'] = () => {};
+
+            var block = new Block.Block(view, null);
+
+            var bindingDesc: Block.IBinding = {};
+            bindingDesc['id'] = '0';
+
+            block.bindings.push(new Block.Binding('0', null, bindingDesc));
+            block.update();
+
+            delete String.prototype['foo'];
+        });
     });
 
     describe('#IfBlock', function () {


### PR DESCRIPTION
@BobNisco , without the fix you wrote, this test reproduces the error I saw in the browser earlier today. I think it would be valuable to include.

@xirzec - the `IBinding` interface doesn't expect `id` to be set on a `bindingDesc`, but the compiler is adding it. Is one or the other incorrect?
